### PR TITLE
Fix to be compatible with CommunityPatch mod

### DIFF
--- a/NoDragonBannerTimeoutSubModule.cs
+++ b/NoDragonBannerTimeoutSubModule.cs
@@ -1,8 +1,11 @@
 ﻿using StoryMode;
+using StoryMode.StoryModePhases;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
+using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 
 namespace NoDragonBannerTimeout
@@ -62,6 +65,101 @@ namespace NoDragonBannerTimeout
         DisplayInfoMsgQuestModifyFailureUserShouldReport(
             "Vanilla quest behavior not found");
       }
+    }
+
+    private static bool IsFirstStoryPhase()
+    {
+      return FirstPhase.Instance != null && SecondPhase.Instance == null;
+    }
+
+    private static void DisableStoryDirectTimeoutAllQuests()
+    {
+      foreach (QuestBase quest in Campaign.Current.QuestManager.Quests
+                   .ToList<QuestBase>())
+      {
+        DisableStoryDirectTimeoutIfNeeded(quest);
+      }
+    }
+
+    private void InitDisableStoryDirectTimeout(Game game)
+    {
+      if (!(game.GameType is StoryMode.CampaignStoryMode))
+        return;
+
+      CampaignEvents.OnQuestStartedEvent.AddNonSerializedListener(
+          this, new Action<QuestBase>(OnQuestStarted));
+      DisableStoryDirectTimeoutAllQuests();
+      // We try to be compatible with Community Patch mod, which also modifies
+      // these quests in it's initialization, and we try not to rely on the
+      // order of loading, so redo the quest changes on the next hourly
+      // tick as well.
+      new NextHourlyTickListener(
+          (quest) => { DisableStoryDirectTimeoutAllQuests(); }, null);
+    }
+
+    private static void DisableStoryDirectTimeoutIfNeeded(QuestBase quest)
+    {
+      if (!IsFirstStoryPhase() || !quest.IsSpecialQuest || !quest.IsOngoing)
+        return;
+
+      CampaignTime newDueTime = CampaignTime.Never;
+      if (quest.QuestDueTime != newDueTime)
+      {
+        quest.ChangeQuestDueTime(newDueTime);
+        ShowNotification(
+            new TextObject("{=!}Quest time remaining was updated."),
+            "event:/ui/notification/quest_update");
+      }
+    }
+
+    private static void ShowNotification(TextObject message,
+                                         string soundEventPath = "")
+    {
+      InformationManager.AddQuickInformation(message, 0, null, soundEventPath);
+    }
+
+    class NextHourlyTickListener
+    {
+      private Action<QuestBase> _func;
+      private QuestBase _quest;
+      private int _count = 0;
+      private int _max;
+
+      public NextHourlyTickListener(Action<QuestBase> func, QuestBase quest,
+                                    int max = 1)
+      {
+        _func = func;
+        _quest = quest;
+        _max = max;
+        CampaignEvents.HourlyTickEvent.AddNonSerializedListener(this,
+                                                                OnHourlyTick);
+      }
+
+      private void OnHourlyTick()
+      {
+        _count++;
+        if (_count >= _max)
+        {
+          _func.Invoke(_quest);
+          CampaignEvents.HourlyTickEvent.ClearListeners(this);
+        }
+      }
+    };
+
+    private void OnQuestStarted(QuestBase quest)
+    {
+      // defer our updates until the next next hourlytick, because we are trying
+      // to undo the changes made by e.g. BannerlordCommunityPatch, who does
+      // them in the next hourly tick after this event.
+      new NextHourlyTickListener(
+          new Action<QuestBase>(DisableStoryDirectTimeoutIfNeeded), quest, 2);
+    }
+
+    public override void OnGameInitializationFinished(Game game)
+    {
+      base.OnGameInitializationFinished(game);
+
+      InitDisableStoryDirectTimeout(game);
     }
 
     public static void DisplayInfoMsg(string msg)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Or, if you're building it here, during post build, the NoDragonBannerTimeout dir
 
 ## Compatibility and Class Overrides:
 
-Is probably not compatible with mods that alter the main storyline quests.
+Is compatible with [Bannerlord Community Patch](https://www.nexusmods.com/mountandblade2bannerlord/mods/186).
 
-Alters the classes StoryMode.Behaviors.FirstPhaseCampaignBehavior in "Modules\StoryMode\bin\Win64_Shipping_Client\StoryMode.dll".
+Is probably not compatible with other mods that alter the main storyline quests.
+
+Alters the classes StoryMode.Behaviors.FirstPhaseCampaignBehavior in "Modules\StoryMode\bin\Win64_Shipping_Client\StoryMode.dll". Also modifies the 'time remaining' property of certain story line quests.
 
 # Credits
 


### PR DESCRIPTION
As of 0.1.0-rc2 CommunityPatch modifies the FirstPhase storyline quests to show that they will fail after 10 game years. It does this by using the QuestDueTime property on top of how vanilla failed them which was through an unrelated tick handler. The result is the same, but the gui will display the days remaining.

We therefore modify them in the opposite way to remove the QuestDueTime setting. As CommunityPatch does this in an HourlyTick handler after the quest starts, we do our changes in the 2nd HourlyTick after quest start to reverse it.